### PR TITLE
UHF-5134: fix problem with broken image upload

### DIFF
--- a/helfi_azure_fs.module
+++ b/helfi_azure_fs.module
@@ -7,7 +7,10 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\file\FileInterface;
+
 
 /**
  * Implements hook_entity_field_storage_info_alter().
@@ -29,5 +32,24 @@ function helfi_azure_fs_entity_field_storage_info_alter(
       continue;
     }
     $field->setSetting('uri_scheme', $scheme);
+  }
+}
+
+/**
+ * Implements hook_file_presave().
+ */
+function helfi_sote_file_presave(FileInterface $file) {
+  $new_filename = str_replace(' ', '_', $file->getFilename());
+
+  if ($new_filename !== $file->getFilename()) {
+    /** @var \Drupal\Core\File\FileSystemInterface $file_system */
+    $file_system = \Drupal::service('file_system');
+    $uri = $file->getFileUri();
+    $directory = $file_system->dirname($uri);
+    $uri = $directory . '/' . $new_filename;
+    if ($new_uri = $file_system->move($file->getFileUri(), $uri, FileSystemInterface::EXISTS_RENAME)) {
+      $file->set('uri', $new_uri);
+      $file->set('filename', $file_system->basename($new_uri));
+    }
   }
 }

--- a/helfi_azure_fs.module
+++ b/helfi_azure_fs.module
@@ -11,7 +11,6 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\file\FileInterface;
 
-
 /**
  * Implements hook_entity_field_storage_info_alter().
  */

--- a/helfi_azure_fs.module
+++ b/helfi_azure_fs.module
@@ -9,7 +9,6 @@ declare(strict_types = 1);
 
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 
 /**

--- a/helfi_azure_fs.module
+++ b/helfi_azure_fs.module
@@ -9,6 +9,7 @@ declare(strict_types = 1);
 
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 
 /**
@@ -37,7 +38,7 @@ function helfi_azure_fs_entity_field_storage_info_alter(
 /**
  * Implements hook_file_presave().
  */
-function helfi_sote_file_presave(FileInterface $file) {
+function helfi_azure_fs_file_presave(FileInterface $file) {
   $new_filename = str_replace(' ', '_', $file->getFilename());
 
   if ($new_filename !== $file->getFilename()) {

--- a/tests/src/Functional/FileNameTransliterateTest.php
+++ b/tests/src/Functional/FileNameTransliterateTest.php
@@ -2,12 +2,7 @@
 
 namespace Drupal\Tests\file\Functional;
 
-use Drupal\Component\Utility\Environment;
-use Drupal\file\Entity\File;
-use Drupal\file\Upload\UploadedFileInterface;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\file\Functional\FileManagedTestBase;
-use Drupal\Tests\TestFileCreationTrait;
 
 /**
  * Tests the file transliteration.
@@ -15,9 +10,6 @@ use Drupal\Tests\TestFileCreationTrait;
  * @group file
  */
 class FileNameTransliterateTest extends FileManagedTestBase {
-  use TestFileCreationTrait {
-    getTestFiles as drupalGetTestFiles;
-  }
 
   /**
    * {@inheritdoc}
@@ -30,44 +22,18 @@ class FileNameTransliterateTest extends FileManagedTestBase {
   protected static $modules = ['helfi_azure_fs', 'file'];
 
   /**
-   * Array of files.
-   *
-   * @var array
-   */
-  private array $imageFiles;
-
-  /**
-   * Bad name for file.
-   *
-   * @var string
-   */
-  private string $brokenFileName = 'my test filename.png';
-
-  /**
-   * Proper name for file.
-   *
-   * @var string
-   */
-  private string $fixedFileName = 'my_test_filename.png';
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function setUp(): void {
-    parent::setUp();
-
-    $this->imageFiles = $this->drupalGetTestFiles('image');
-  }
-
-  /**
    * Tests name transliteration.
    */
   public function testFileNameTransliteration() {
-    $image_file = (array) current($this->imageFiles);
-    $image_file['filename'] = $this->brokenFileName;
-    $image = File::create($image_file);
+    $image = $this->createFile(NULL, $this->randomMachineName());
+
+    $brokenFileName = 'my test filename.png';
+    $fixedFileName = 'my_test_filename.png';
+
+    $image->setFilename($brokenFileName);
     $image->save();
-    $this->assertEquals($this->fixedFileName, $image->getFilename());
+
+    $this->assertEquals($fixedFileName, $image->getFilename());
   }
 
 }

--- a/tests/src/Functional/FileNameTransliterateTest.php
+++ b/tests/src/Functional/FileNameTransliterateTest.php
@@ -60,7 +60,7 @@ class FileNameTransliterateTest extends FileManagedTestBase {
   }
 
   /**
-   * Tests file size upload errors.
+   * Tests name transliteration.
    */
   public function testFileNameTransliteration() {
     $image_file = (array) current($this->imageFiles);

--- a/tests/src/Functional/FileNameTransliterateTest.php
+++ b/tests/src/Functional/FileNameTransliterateTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\Tests\file\Functional;
+
+use Drupal\Component\Utility\Environment;
+use Drupal\file\Entity\File;
+use Drupal\file\Upload\UploadedFileInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\file\Functional\FileManagedTestBase;
+use Drupal\Tests\TestFileCreationTrait;
+
+/**
+ * Tests the file transliteration.
+ *
+ * @group file
+ */
+class FileNameTransliterateTest extends FileManagedTestBase {
+  use TestFileCreationTrait {
+    getTestFiles as drupalGetTestFiles;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['helfi_azure_fs', 'file'];
+
+  /**
+   * Array of files.
+   *
+   * @var array
+   */
+  private array $imageFiles;
+
+  /**
+   * Bad name for file.
+   *
+   * @var string
+   */
+  private string $brokenFileName = 'my test filename.png';
+
+  /**
+   * Proper name for file.
+   *
+   * @var string
+   */
+  private string $fixedFileName = 'my_test_filename.png';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->imageFiles = $this->drupalGetTestFiles('image');
+  }
+
+  /**
+   * Tests file size upload errors.
+   */
+  public function testFileNameTransliteration() {
+    $image_file = (array) current($this->imageFiles);
+    $image_file['filename'] = $this->brokenFileName;
+    $image = File::create($image_file);
+    $image->save();
+    $this->assertEquals($this->fixedFileName, $image->getFilename());
+  }
+
+}

--- a/tests/src/Functional/FileNameTransliterateTest.php
+++ b/tests/src/Functional/FileNameTransliterateTest.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\Tests\file\Functional;
 
-use Drupal\Tests\file\Functional\FileManagedTestBase;
-
 /**
  * Tests the file transliteration.
  *
@@ -34,6 +32,12 @@ class FileNameTransliterateTest extends FileManagedTestBase {
     $image->save();
 
     $this->assertEquals($fixedFileName, $image->getFilename());
+
+    $image2 = $this->createFile(NULL, $this->randomMachineName());
+    $image2->setFilename($brokenFileName);
+    $image2->save();
+
+    $this->assertEquals('my_test_filename_0.png', $image2->getFilename());
   }
 
 }


### PR DESCRIPTION
Uploading images with spaces in the name of the file caused problem since image derivatives were not created. Added code which replaces spaces from filenames with underscores

How to reproduce the bug:
- Create new content or add new content
- Upload new image to the content, the name of the file should have spaces in it (for example mummo jumppaa yritys 100.jpg)
  - You should not see the thumbnail for the image since the bug

How to test:
- Create new content or add new content
- Upload new image to the content, the name of the file should have spaces in it (for example "mummo jumppaa yritys 100.jpg")
- After you have chosen the image, you should see the preview thumbnail.
- Select the image and save the content
- Go to the content page, you should see the image in correct size.