### PR TITLE
UHF-7959: Construct client without connection string so we can skip deprecated function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ $schemes = [
     'config' => [
       'name' => '[ insert account name here ]',
       'token' => '[ insert sas token here ]',
+      'container' => '[ insert container name here ]',
       'endpointSuffix' => 'core.windows.net',
       'protocol' => 'https',
     ],

--- a/src/Flysystem/Azure.php
+++ b/src/Flysystem/Azure.php
@@ -71,6 +71,9 @@ final class Azure extends AzureBase {
    */
   public function getClient(): BlobRestProxy {
     if (!isset($this->client)) {
+      // Construct the client manually to avoid calling substr with null
+      // $haystack parameter.
+      // @see https://github.com/Azure/azure-storage-php/issues/347
       $wrapper = new BlobRestProxy(
         $this->getBlobUri(),
         $this->getBlobUri(Resources::SECONDARY_STRING),


### PR DESCRIPTION
## How to install

- `composer require drupal/helfi_azure_fs:dev-UHF-7959`
- `drush cr`
- See documentation https://github.com/City-of-Helsinki/drupal-module-helfi-azure-fs/blob/main/README.md#testing-on-local how to set up blob storage on local env

## How to test

- Upload a new image and make sure the image is served from Azure blob storage (the URL should be something like https://xxxxx.core.windows.net)
- Make sure no deprecation error is logged (`docker compose logs app`). Should be something like:
```
Deprecated function: substr(): Passing null to parameter #1 ($string) of type string is deprecated in MicrosoftAzure\\Storage\\Common\\Internal\\Utilities::endsWith() (line 615 of \/var\/www\/html\/vendor\/microsoft\/azure-storage-common\/src\/Common\/Internal\/Utilities.php) #0 \/var\/www\/html\/public\/core\/includes\/bootstrap.inc(347): _drupal_error_handler_real()\n#1 [internal function]: _drupal_error_handler()\n#2 \/var\/www\/html\/vendor\/microsoft\/azure-storage-common\/src\/Common\/Internal\/Utilities.php(615): substr()\n#3 \/var\/www\/html\/vendor\/microsoft\/azure-storage-common\/src\/Common\/Internal\/Utilities.php(815): MicrosoftAzure\\Storage\\Common\\Internal\\Utilities::endsWith()\n#4 \/var\/www\/html\/vendor\/microsoft\/azure-storage-common\/src\/Common\/Internal\/ServiceRestProxy.php(80):
...
```

