### PR TITLE
UHF-8390: drop core version 8, addad 10

### DIFF
--- a/helfi_azure_fs.info.yml
+++ b/helfi_azure_fs.info.yml
@@ -1,5 +1,4 @@
 name: HELfi azure file system
 type: module
 package: Custom
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10


### PR DESCRIPTION
Fixed version number

How to test:

composer require drupal/helfi_azure_fs:dev-UHF-8390
composer require drupal/upgrade_status and drush en -y upgrade_status
run drush upgrade_status:analyze helfi_azure_fs
You should only see deprecation errors from prophecy / prophesize method.