### PR TITLE
PLATTA-4843 images with url special chars should be url encoded

### DIFF
--- a/helfi_azure_fs.module
+++ b/helfi_azure_fs.module
@@ -7,8 +7,8 @@
 
 declare(strict_types = 1);
 
-use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\file\FileInterface;
 
 /**

--- a/helfi_azure_fs.module
+++ b/helfi_azure_fs.module
@@ -38,7 +38,7 @@ function helfi_azure_fs_entity_field_storage_info_alter(
  * Implements hook_file_presave().
  */
 function helfi_azure_fs_file_presave(FileInterface $file) : void {
-  $new_filename = str_replace(' ', '_', $file->getFilename());
+  $new_filename = preg_replace('/[ +]/', '_', $file->getFilename());
 
   if ($new_filename !== $file->getFilename()) {
     /** @var \Drupal\Core\File\FileSystemInterface $file_system */

--- a/src/Flysystem/Azure.php
+++ b/src/Flysystem/Azure.php
@@ -118,7 +118,7 @@ final class Azure extends AzureBase {
       // to be decoupled from main request.
       $uri = str_replace('azure://', 'public://', $uri);
 
-      return UrlHelper::encodePath($this->fileUrlGenerator->generateString($uri));
+      return $this->fileUrlGenerator->generateString(UrlHelper::encodePath($uri));
     }
     $target = $this->getTarget($uri);
 

--- a/src/Flysystem/Azure.php
+++ b/src/Flysystem/Azure.php
@@ -118,7 +118,7 @@ final class Azure extends AzureBase {
       // to be decoupled from main request.
       $uri = str_replace('azure://', 'public://', $uri);
 
-      return $this->fileUrlGenerator->generateString($uri);
+      return UrlHelper::encodePath($this->fileUrlGenerator->generateString($uri));
     }
     $target = $this->getTarget($uri);
 

--- a/src/Flysystem/Azure.php
+++ b/src/Flysystem/Azure.php
@@ -118,7 +118,7 @@ final class Azure extends AzureBase {
       // to be decoupled from main request.
       $uri = str_replace('azure://', 'public://', $uri);
 
-      return $this->fileUrlGenerator->generateString(UrlHelper::encodePath($uri));
+      return $this->fileUrlGenerator->generateString($uri);
     }
     $target = $this->getTarget($uri);
 

--- a/tests/src/Functional/FileNameTransliterateTest.php
+++ b/tests/src/Functional/FileNameTransliterateTest.php
@@ -25,8 +25,8 @@ class FileNameTransliterateTest extends FileManagedTestBase {
   public function testFileNameTransliteration() {
     $image = $this->createFile(NULL, $this->randomMachineName());
 
-    $brokenFileName = 'my test filename.png';
-    $fixedFileName = 'my_test_filename.png';
+    $brokenFileName = 'my test+filename+something else.png';
+    $fixedFileName = 'my_test_filename_something_else.png';
 
     $image->setFilename($brokenFileName);
     $image->save();
@@ -37,7 +37,8 @@ class FileNameTransliterateTest extends FileManagedTestBase {
     $image2->setFilename($brokenFileName);
     $image2->save();
 
-    $this->assertEquals('my_test_filename_0.png', $image2->getFilename());
+    $this->assertEquals('my_test_filename_something_else_0.png',
+      $image2->getFilename());
   }
 
 }

--- a/tests/src/Unit/AzureTest.php
+++ b/tests/src/Unit/AzureTest.php
@@ -34,7 +34,7 @@ class AzureTest extends UnitTestCase {
     vfsStream::setup('flysystem');
     $fileUrlGenerator = $this->prophesize(FileUrlGeneratorInterface::class);
     $fileUrlGenerator->generateString(Argument::any())
-      ->shouldBeCalledTimes()
+      ->shouldBeCalledTimes(2)
       ->willReturn(
         '/styles/test.jpg',
         '/styles/test).jpg',

--- a/tests/src/Unit/AzureTest.php
+++ b/tests/src/Unit/AzureTest.php
@@ -36,7 +36,7 @@ class AzureTest extends UnitTestCase {
     $fileUrlGenerator->generateString(Argument::any())
       ->shouldBeCalledTimes(1)
       ->willReturn(
-        '/styles/test.jpg',
+        '/styles/test).jpg',
       );
     $loggerFactory = new LoggerChannelFactory();
     $loggerFactory->addLogger($this->prophesize(LoggerInterface::class)->reveal());
@@ -53,17 +53,8 @@ class AzureTest extends UnitTestCase {
     $container->set('file_url_generator', $fileUrlGenerator->reveal());
     $azure = Azure::create($container, $configuration, 'helfi_azure', []);
     // Make sure non-image style URLs are served directly from blob storage.
-    $this->assertEquals('https://test.blob.core.windows.net/test/test.jpg', $azure->getExternalUrl('vfs://test.jpg'));
-    // Make sure image style URL is passed to file url generator service.
-    $this->assertEquals('/styles/test.jpg', $azure->getExternalUrl('vfs://styles/test.jpg'));
-
-    // Make sure url is encoded.
-    $fileUrlGenerator = $this->prophesize(FileUrlGeneratorInterface::class);
-    $fileUrlGenerator->generateString(Argument::any())
-      ->shouldBeCalledTimes(1)
-      ->willReturn(
-        '/styles/test).jpg',
-      );
+    $this->assertEquals('https://test.blob.core.windows.net/test/test%29.jpg', $azure->getExternalUrl('vfs://test).jpg'));
+    // Make sure image style URL is passed to file url generator service and is encoded.
     $this->assertEquals('/styles/test%29.jpg', $azure->getExternalUrl('vfs://styles/test).jpg'));
   }
 

--- a/tests/src/Unit/AzureTest.php
+++ b/tests/src/Unit/AzureTest.php
@@ -36,6 +36,7 @@ class AzureTest extends UnitTestCase {
     $fileUrlGenerator->generateString(Argument::any())
       ->shouldBeCalledTimes(1)
       ->willReturn(
+        '/styles/test.jpg',
         '/styles/test).jpg',
       );
     $loggerFactory = new LoggerChannelFactory();
@@ -53,8 +54,12 @@ class AzureTest extends UnitTestCase {
     $container->set('file_url_generator', $fileUrlGenerator->reveal());
     $azure = Azure::create($container, $configuration, 'helfi_azure', []);
     // Make sure non-image style URLs are served directly from blob storage.
-    $this->assertEquals('https://test.blob.core.windows.net/test/test%29.jpg', $azure->getExternalUrl('vfs://test).jpg'));
+    $this->assertEquals('https://test.blob.core.windows.net/test/test.jpg', $azure->getExternalUrl('vfs://test.jpg'));
     // Make sure image style URL is passed to file url generator service and is encoded.
+    $this->assertEquals('/styles/test.jpg', $azure->getExternalUrl('vfs://styles/test.jpg'));
+
+    // Check that file uri is encoded.
+    $this->assertEquals('https://test.blob.core.windows.net/test/test%29.jpg', $azure->getExternalUrl('vfs://test).jpg'));
     $this->assertEquals('/styles/test%29.jpg', $azure->getExternalUrl('vfs://styles/test).jpg'));
   }
 

--- a/tests/src/Unit/AzureTest.php
+++ b/tests/src/Unit/AzureTest.php
@@ -58,6 +58,7 @@ class AzureTest extends UnitTestCase {
     $this->assertEquals('/styles/test.jpg', $azure->getExternalUrl('vfs://styles/test.jpg'));
 
     // Make sure url is encoded.
+    $fileUrlGenerator = $this->prophesize(FileUrlGeneratorInterface::class);
     $fileUrlGenerator->generateString(Argument::any())
       ->shouldBeCalledTimes(1)
       ->willReturn(

--- a/tests/src/Unit/AzureTest.php
+++ b/tests/src/Unit/AzureTest.php
@@ -34,7 +34,7 @@ class AzureTest extends UnitTestCase {
     vfsStream::setup('flysystem');
     $fileUrlGenerator = $this->prophesize(FileUrlGeneratorInterface::class);
     $fileUrlGenerator->generateString(Argument::any())
-      ->shouldBeCalledTimes(1)
+      ->shouldBeCalledTimes(2)
       ->willReturn(
         '/styles/test.jpg',
         '/styles/test).jpg',

--- a/tests/src/Unit/AzureTest.php
+++ b/tests/src/Unit/AzureTest.php
@@ -34,7 +34,7 @@ class AzureTest extends UnitTestCase {
     vfsStream::setup('flysystem');
     $fileUrlGenerator = $this->prophesize(FileUrlGeneratorInterface::class);
     $fileUrlGenerator->generateString(Argument::any())
-      ->shouldBeCalledTimes(2)
+      ->shouldBeCalledTimes()
       ->willReturn(
         '/styles/test.jpg',
         '/styles/test).jpg',
@@ -55,7 +55,7 @@ class AzureTest extends UnitTestCase {
     $azure = Azure::create($container, $configuration, 'helfi_azure', []);
     // Make sure non-image style URLs are served directly from blob storage.
     $this->assertEquals('https://test.blob.core.windows.net/test/test.jpg', $azure->getExternalUrl('vfs://test.jpg'));
-    // Make sure image style URL is passed to file url generator service and is encoded.
+    // Make sure image style URL is passed to file url generator service.
     $this->assertEquals('/styles/test.jpg', $azure->getExternalUrl('vfs://styles/test.jpg'));
 
     // Check that file uri is encoded.

--- a/tests/src/Unit/AzureTest.php
+++ b/tests/src/Unit/AzureTest.php
@@ -36,7 +36,7 @@ class AzureTest extends UnitTestCase {
     $fileUrlGenerator->generateString(Argument::any())
       ->shouldBeCalledTimes(1)
       ->willReturn(
-        'https://localhost/styles/test.jpg',
+        '/styles/test.jpg',
       );
     $loggerFactory = new LoggerChannelFactory();
     $loggerFactory->addLogger($this->prophesize(LoggerInterface::class)->reveal());
@@ -55,7 +55,15 @@ class AzureTest extends UnitTestCase {
     // Make sure non-image style URLs are served directly from blob storage.
     $this->assertEquals('https://test.blob.core.windows.net/test/test.jpg', $azure->getExternalUrl('vfs://test.jpg'));
     // Make sure image style URL is passed to file url generator service.
-    $this->assertEquals('https://localhost/styles/test.jpg', $azure->getExternalUrl('vfs://styles/test.jpg'));
+    $this->assertEquals('/styles/test.jpg', $azure->getExternalUrl('vfs://styles/test.jpg'));
+
+    // Make sure url is encoded.
+    $fileUrlGenerator->generateString(Argument::any())
+      ->shouldBeCalledTimes(1)
+      ->willReturn(
+        '/styles/test).jpg',
+      );
+    $this->assertEquals('/styles/test%29.jpg', $azure->getExternalUrl('vfs://styles/test).jpg'));
   }
 
   /**


### PR DESCRIPTION
Images with for example + in their name should be outputed with the + sign url encoded, so that nginx will interpret that correctly, not as space