### PR TITLE
PLATTA-4951 - prevent multiple file_exists being called for same file during same req

### DIFF
--- a/src/Flysystem/Azure.php
+++ b/src/Flysystem/Azure.php
@@ -39,7 +39,6 @@ final class Azure extends AzureBase {
    */
   private array $externalUrls = [];
 
-
   /**
    * {@inheritdoc}
    */

--- a/src/Flysystem/Azure.php
+++ b/src/Flysystem/Azure.php
@@ -33,6 +33,14 @@ final class Azure extends AzureBase {
   private FileUrlGeneratorInterface $fileUrlGenerator;
 
   /**
+   * List of urls already requested, indexed by uri.
+   *
+   * @var string[]
+   */
+  private array $externalUrls = [];
+
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : self {
@@ -106,6 +114,11 @@ final class Azure extends AzureBase {
    * {@inheritdoc}
    */
   public function getExternalUrl($uri): string {
+    // This could get called multiple times in a request, currently 2 times,
+    // and the file_exists below takes time, so we use a 'static' cache.
+    if (isset($this->externalUrls[$uri])) {
+      return $this->externalUrls[$uri];
+    }
     // The original ::getExternalUrl method generates image styles on the fly,
     // blocking the request until all derivatives on that page are generated.
     // We use 'responsive_image' module, so each image can generate up to
@@ -116,13 +129,15 @@ final class Azure extends AzureBase {
       // copied to Azure blob storage. Each derivative is generated when the
       // image style URL is called for the first time, allowing the generation
       // to be decoupled from main request.
-      $uri = str_replace('azure://', 'public://', $uri);
+      $localUri = str_replace('azure://', 'public://', $uri);
 
-      return $this->fileUrlGenerator->generateString($uri);
+      return $this->externalUrls[$uri] = $this->fileUrlGenerator
+        ->generateString($localUri);
     }
     $target = $this->getTarget($uri);
 
-    return sprintf('%s/%s', $this->calculateUrlPrefix(), UrlHelper::encodePath($target));
+    return $this->externalUrls[$uri] = sprintf('%s/%s',
+      $this->calculateUrlPrefix(), UrlHelper::encodePath($target));
   }
 
 }

--- a/tests/src/Unit/AzureTest.php
+++ b/tests/src/Unit/AzureTest.php
@@ -61,6 +61,10 @@ class AzureTest extends UnitTestCase {
     // Check that file uri is encoded.
     $this->assertEquals('https://test.blob.core.windows.net/test/test%29.jpg', $azure->getExternalUrl('vfs://test).jpg'));
     $this->assertEquals('/styles/test%29.jpg', $azure->getExternalUrl('vfs://styles/test).jpg'));
+
+    // Test static cache, as generateString should not be called 3rd time
+    // and is restricted above to 2 calls.
+    $this->assertEquals('/styles/test.jpg', $azure->getExternalUrl('vfs://styles/test.jpg'));
   }
 
   /**


### PR DESCRIPTION
Currently, getExternalUrl is called twice for same file during a request, and file_exists takes time to check in blob if is there or not.
When lots of images on same page and having responsive images, can quickly go to 70 * 2 getExternalUrl calls.