### PR TITLE
UHF-8255 Remove email from contact section that is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,3 @@ The correct values can be found by running `printenv | grep AZURE_BLOB_STORAGE` 
 ## Contact
 
 Slack: #helfi-drupal (http://helsinkicity.slack.com/)
-
-Mail: `drupal@hel.fi`


### PR DESCRIPTION
Check the README that the email drupal@hel.fi is no longer in there.
