### PR TITLE
UHF-X: PHP 8.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,12 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "drupal/coder": "^8.3"
+    },
+    "extra": {
+        "patches": {
+            "twistor/flysystem-stream-wrapper": {
+                "PHP 8.2 support (https://www.drupal.org/project/flysystem/issues/3387094)": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-module-helfi-azure-fs/ddb222622b92d1c2b7db975a84167a00579a1ad0/patches/3387094-add-context-property-to-stream-wrapper.patch"
+            }
+        }
     }
 }

--- a/patches/3387094-add-context-property-to-stream-wrapper.patch
+++ b/patches/3387094-add-context-property-to-stream-wrapper.patch
@@ -1,0 +1,18 @@
+diff --git a/src/FlysystemStreamWrapper.php b/src/FlysystemStreamWrapper.php
+index 93a79b6..5c5a200 100644
+--- a/src/FlysystemStreamWrapper.php
++++ b/src/FlysystemStreamWrapper.php
+@@ -25,6 +25,13 @@ class FlysystemStreamWrapper
+      */
+     const STREAM_URL_IGNORE_SIZE = 8;
+ 
++    /**
++     * PHP-passed stream context.
++     *
++     * @var resource|null
++     */
++    public $context;
++
+     /**
+      * The registered filesystems.
+      *


### PR DESCRIPTION
Add `$context` property to flysystem stream wrapper
    
PHP requires that stream wrapper implementations have `$context` property. Since PHP 8.2, assigning dynamic properties is deprecated, so unless the property is defined, we get a lot of warnings to logs.

This property is missing from `drupal/flysystem` stream wrappers.

Drupal.org issue: https://www.drupal.org/project/flysystem/issues/3387094