### PR TITLE
UHF-X: Remove deprecated code

### DIFF
--- a/helfi_azure_fs.install
+++ b/helfi_azure_fs.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Contains helfi azure fs install hook implementations.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Uninstall flysystem_azure module.
+ */
+function helfi_azure_fs_update_90201() {
+  \Drupal::service('module_installer')->uninstall([
+    'flysystem_azure',
+  ]);
+}

--- a/src/AzureFileSystem.php
+++ b/src/AzureFileSystem.php
@@ -50,12 +50,6 @@ final class AzureFileSystem extends FileSystem {
   ) {
     $this->skipFsOperations = $settings::get('is_azure', FALSE);
 
-    // @todo Keep this backward compatible in case someone is not using
-    // the latest platform. Remove in 2.x release.
-    if (!$this->skipFsOperations) {
-      $this->skipFsOperations = (bool) getenv('OPENSHIFT_BUILD_NAMESPACE');
-    }
-
     parent::__construct($streamWrapperManager, $settings, $logger);
   }
 

--- a/tests/src/Unit/AzureFileSystemTest.php
+++ b/tests/src/Unit/AzureFileSystemTest.php
@@ -55,11 +55,6 @@ class AzureFileSystemTest extends UnitTestCase {
 
     $fs = $this->getSut($decorated, new Settings(['is_azure' => TRUE]));
     $this->assertTrue($fs->chmod($uri));
-
-    // Test backward compatibility settings.
-    putenv('OPENSHIFT_BUILD_NAMESPACE=123');
-    $fs = $this->getSut($decorated, new Settings([]));
-    $this->assertTrue($fs->chmod($uri));
   }
 
   /**
@@ -70,8 +65,6 @@ class AzureFileSystemTest extends UnitTestCase {
     vfsStream::setup('dir');
     vfsStream::create($structure);
 
-    // Make sure BC setting is not set.
-    putenv('OPENSHIFT_BUILD_NAMESPACE=');
     // Make sure decorated service is called when 'skipFsOperations'
     // is disabled.
     $decorated = $this->prophesize(FileSystemInterface::class);


### PR DESCRIPTION
- Remove support for `OPENSHIFT_BUILD_NAMESPACE` environment variable.
- Uninstall `flysystem_azure` in an update hook, since it is no longer required by `^2.0.0`.