### PR TITLE
UHF-10891: Initial command to transliterate filenames embbed in text fields

### DIFF
--- a/src/Drush/Commands/TransliterateFilesCommands.php
+++ b/src/Drush/Commands/TransliterateFilesCommands.php
@@ -46,7 +46,6 @@ final class TransliterateFilesCommands extends DrushCommands {
     private readonly EntityFieldManagerInterface $entityFieldManager,
     private readonly ClientInterface $httpClient,
   ) {
-    $this->io = new SymfonyStyle($this->input(), $this->output());
     parent::__construct();
   }
 

--- a/src/Drush/Commands/TransliterateFilesCommands.php
+++ b/src/Drush/Commands/TransliterateFilesCommands.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_azure_fs\Drush\Commands;
 
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\Event\FileUploadSanitizeNameEvent;
 use Drupal\Core\File\Exception\FileException;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 use Drupal\file\Entity\File;
-use Drupal\file\FileInterface;
 use Drush\Attributes\Command;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ClientException;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -38,6 +42,8 @@ final class TransliterateFilesCommands extends DrushCommands {
     private readonly EventDispatcherInterface $eventDispatcher,
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly FileSystemInterface $fileSystem,
+    private readonly EntityFieldManagerInterface $entityFieldManager,
+    private readonly ClientInterface $httpClient,
   ) {
     $this->io = new SymfonyStyle($this->input(), $this->output());
     parent::__construct();
@@ -46,17 +52,154 @@ final class TransliterateFilesCommands extends DrushCommands {
   /**
    * Gets the sanitized filename.
    *
-   * @param \Drupal\file\FileInterface $file
+   * @param string $filename
    *   The file to sanitize.
    *
    * @return string
    *   The sanitized filename.
    */
-  private function getSanitizedFilename(FileInterface $file): string {
-    $event = new FileUploadSanitizeNameEvent($file->getFilename(), '');
+  private function getSanitizedFilename(string $filename): string {
+    $event = new FileUploadSanitizeNameEvent($filename, '');
     $this->eventDispatcher->dispatch($event);
 
     return $event->getFilename();
+  }
+
+  /**
+   * Processes all fields for given entity type.
+   *
+   * @param string $entityType
+   *   The entity type to process.
+   * @param array $fields
+   *   The fields to process.
+   */
+  private function processEntityType(string $entityType, array $fields) : void {
+    foreach ($fields as $name => $field) {
+      $query = $this->entityTypeManager
+        ->getStorage($entityType)
+        ->getQuery();
+      // Only load entities that has link to a local or MS blob
+      // storage file.
+      $conditionGroup = $query->orConditionGroup();
+      $conditionGroup
+        ->condition($name, '%blob.core.windows.net%', 'LIKE');
+      $conditionGroup
+        ->condition($name, '/sites/default/files%', 'LIKE');
+      $query->exists($name)
+        ->condition($conditionGroup)
+        ->accessCheck(FALSE);
+      $ids = $query->execute();
+
+      foreach ($ids as $id) {
+        $entity = $this->entityTypeManager->getStorage($entityType)
+          ->load($id);
+
+        foreach ($entity->getTranslationLanguages() as $language) {
+          $this->processFieldLinks($entity->getTranslation($language->getId()), $name);
+        }
+      }
+    }
+  }
+
+  /**
+   * Checks if the given remote file exists.
+   *
+   * @param string $url
+   *   The url to check.
+   *
+   * @return bool
+   *   TRUE if remote file exists, FALSE if not.
+   */
+  private function remoteFileExists(string $url) : bool {
+    try {
+      $this->httpClient->head($url);
+
+      return TRUE;
+    }
+    catch (ClientException) {
+    }
+    return FALSE;
+  }
+
+  /**
+   * Sanitize filenames inside text fields.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity translation to process.
+   * @param string $fieldName
+   *   The field name.
+   */
+  private function processFieldLinks(ContentEntityInterface $entity, string $fieldName) : void {
+    if (!$value = $entity->get($fieldName)->value) {
+      return;
+    }
+
+    $hasChanges = FALSE;
+    $dom = Html::load($value);
+    /** @var \DOMElement $node */
+    foreach ($dom->getElementsByTagName('a') as $node) {
+      // Nothing to do if link has no href.
+      if (!$href = $node->getAttribute('href')) {
+        continue;
+      }
+      // Do nothing if file exists already.
+      if ($this->remoteFileExists($href)) {
+        continue;
+      }
+      $basename = basename($href);
+
+      // Test sanitized filename and urldecoded+sanitized filename.
+      $candidates = [
+        $this->getSanitizedFilename($basename),
+        $this->getSanitizedFilename(urldecode($basename)),
+      ];
+
+      $newUrl = NULL;
+      foreach ($candidates as $candidate) {
+        $sanitizedUrl = str_replace($basename, $candidate, $href);
+
+        if (!$this->remoteFileExists($sanitizedUrl)) {
+          continue;
+        }
+        $newUrl = $sanitizedUrl;
+      }
+
+      if (!$newUrl) {
+        $this->io()->warning(sprintf('Failed to process the link "%s" for "%s"', $href, $entity->toUrl()->toString()));
+
+        continue;
+      }
+      $hasChanges = TRUE;
+      $value = str_replace($href, $newUrl, $value);
+    }
+
+    if ($hasChanges) {
+      $entity->set($fieldName, $value);
+      $entity->save();
+    }
+  }
+
+  /**
+   * Transliterates all files embedded in text fields.
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'helfi:transliterate:fields')]
+  public function transliterateTextFields() : int {
+    $fieldTypes = [
+      'text_with_summary',
+      'text',
+      'text_long',
+    ];
+    foreach ($fieldTypes as $fieldType) {
+      $fieldMap = $this->entityFieldManager->getFieldMapByFieldType($fieldType);
+
+      foreach ($fieldMap as $entityType => $fields) {
+        $this->processEntityType($entityType, $fields);
+      }
+    }
+    return DrushCommands::EXIT_SUCCESS;
   }
 
   /**
@@ -65,7 +208,7 @@ final class TransliterateFilesCommands extends DrushCommands {
    * @return int
    *   The exit code.
    */
-  #[Command(name: 'helfi:files:transliterate')]
+  #[Command(name: 'helfi:transliterate:files')]
   public function transliterate() : int {
     $ids = $this->entityTypeManager
       ->getStorage('file')
@@ -78,7 +221,7 @@ final class TransliterateFilesCommands extends DrushCommands {
         continue;
       }
 
-      $sanitizedFilename = $this->getSanitizedFilename($file);
+      $sanitizedFilename = $this->getSanitizedFilename($file->getFilename());
 
       if ($sanitizedFilename === $file->getFilename()) {
         continue;

--- a/src/Drush/Commands/TransliterateFilesCommands.php
+++ b/src/Drush/Commands/TransliterateFilesCommands.php
@@ -18,7 +18,6 @@ use Drush\Attributes\Command;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 

--- a/src/Drush/Commands/TransliterateFilesCommands.php
+++ b/src/Drush/Commands/TransliterateFilesCommands.php
@@ -187,7 +187,7 @@ final class TransliterateFilesCommands extends DrushCommands {
       }
 
       if (!$newUrl) {
-        $this->io()->warning(sprintf('Failed to process: "%s"', $href));
+        $this->io()->warning(sprintf('Failed to process [entity id: %s, entity type: %s]: "%s"', $entity->id(), $entity->getEntityTypeId(), $href));
 
         continue;
       }

--- a/src/Drush/Commands/TransliterateFilesCommands.php
+++ b/src/Drush/Commands/TransliterateFilesCommands.php
@@ -146,6 +146,7 @@ final class TransliterateFilesCommands extends DrushCommands {
       if ($this->remoteFileExists($href)) {
         continue;
       }
+      $this->io()->note(sprintf('Found a broken link [%s]: "%s"', $entity->toUrl()->toString(), $href));
       $basename = basename($href);
 
       // Test sanitized filename and urldecoded+sanitized filename.
@@ -165,7 +166,7 @@ final class TransliterateFilesCommands extends DrushCommands {
       }
 
       if (!$newUrl) {
-        $this->io()->warning(sprintf('Failed to process the link "%s" for "%s"', $href, $entity->toUrl()->toString()));
+        $this->io()->warning(sprintf('Failed to process [%s]: "%s"', $entity->toUrl()->toString(), $href));
 
         continue;
       }

--- a/src/Drush/Commands/TransliterateFilesCommands.php
+++ b/src/Drush/Commands/TransliterateFilesCommands.php
@@ -19,7 +19,6 @@ use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**

--- a/tests/src/Kernel/TransliterateFilesCommandsTest.php
+++ b/tests/src/Kernel/TransliterateFilesCommandsTest.php
@@ -8,7 +8,6 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Tests\field\Kernel\FieldKernelTestBase;
 use Drupal\helfi_azure_fs\AzureFileSystem;
 use Drupal\helfi_azure_fs\Drush\Commands\TransliterateFilesCommands;
-use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
 
 /**
  * Tests transliterate file Drush command.
@@ -16,8 +15,6 @@ use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
  * @group helfi_azure_fs
  */
 class TransliterateFilesCommandsTest extends FieldKernelTestBase {
-
-  use ApiTestTrait;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Kernel/TransliterateFilesCommandsTest.php
+++ b/tests/src/Kernel/TransliterateFilesCommandsTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Tests\field\Kernel\FieldKernelTestBase;
 use Drupal\helfi_azure_fs\AzureFileSystem;
 use Drupal\helfi_azure_fs\Drush\Commands\TransliterateFilesCommands;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
 
 /**
  * Tests transliterate file Drush command.
@@ -15,6 +16,8 @@ use Drupal\helfi_azure_fs\Drush\Commands\TransliterateFilesCommands;
  * @group helfi_azure_fs
  */
 class TransliterateFilesCommandsTest extends FieldKernelTestBase {
+
+  use ApiTestTrait;
 
   /**
    * {@inheritdoc}
@@ -72,12 +75,7 @@ class TransliterateFilesCommandsTest extends FieldKernelTestBase {
         'replacement_character' => '_',
       ])->save();
 
-    $command = new TransliterateFilesCommands(
-      $this->container->get('stream_wrapper_manager'),
-      $this->container->get('event_dispatcher'),
-      $this->container->get('entity_type.manager'),
-      $fileSystem,
-    );
+    $command = TransliterateFilesCommands::create($this->container);
     $command->transliterate();
 
     foreach ($files as $expected) {


### PR DESCRIPTION
## How to install

- composer require drupal/helfi_azure_fs:dev-UHF-10891

## How to test

* [ ] Run `drush helfi:transliterate:fields`