### PR TITLE
UHF-10737: configure core file delete

### DIFF
--- a/helfi_azure_fs.install
+++ b/helfi_azure_fs.install
@@ -29,6 +29,7 @@ function helfi_azure_fs_install($is_syncing) : void {
       'lowercase' => TRUE,
       'replacement_character' => '_',
     ])
+    ->set('make_unused_managed_files_temporary', TRUE)
     ->save();
 }
 
@@ -45,5 +46,12 @@ function helfi_azure_fs_update_90201() : void {
  * Make sure file sanitize settings are enabled.
  */
 function helfi_azure_fs_update_90202() : void {
+  helfi_azure_fs_install(FALSE);
+}
+
+/**
+ * Make sure unused files are removed.
+ */
+function helfi_azure_fs_update_90203() : void {
   helfi_azure_fs_install(FALSE);
 }

--- a/helfi_azure_fs.install
+++ b/helfi_azure_fs.install
@@ -31,6 +31,11 @@ function helfi_azure_fs_install($is_syncing) : void {
     ])
     ->set('make_unused_managed_files_temporary', TRUE)
     ->save();
+
+  // 6 hours.
+  \Drupal::configFactory()->getEditable('system.file')
+    ->set('temporary_maximum_age', 21600)
+    ->save();
 }
 
 /**

--- a/src/Drush/Commands/FileCleanerCommands.php
+++ b/src/Drush/Commands/FileCleanerCommands.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_azure_fs\Drush\Commands;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\file\FileInterface;
+use Drush\Attributes\Command;
+use Drush\Commands\AutowireTrait;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush commands for cleaning files.
+ *
+ * Clean files hat were marked permanent because of misconfigured settings.
+ * See UHF-10737.
+ *
+ * @todo delete this. the command is not useful after the files have been cleaned.
+ */
+class FileCleanerCommands extends DrushCommands {
+
+  use AutowireTrait;
+
+  /**
+   * Constructs a new instance.
+   */
+  public function __construct(
+    private readonly Connection $connection,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Transliterates the existing filenames.
+   *
+   * @see \Drupal\file\FileUsage\DatabaseFileUsageBackend::listUsage()
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'helfi:clean:permanent-files')]
+  public function clean(array $options = ['no-dry-run' => FALSE]): int {
+    $query = $this->connection->select('file_managed', 'f');
+
+    // Left join because file_usage might not exist.
+    $query->leftJoin('file_usage', 'fu', 'f.fid = fu.fid AND fu.count > 0');
+    $query
+      ->fields('f', ['fid'])
+      // Permanent only files since temporary files are deleted automatically.
+      ->condition('f.status', FileInterface::STATUS_PERMANENT)
+      // Filter for rows for which file_usage was not found.
+      ->isNull('fu.fid');
+
+    foreach ($query->execute() as $result) {
+      /** @var \Drupal\file\FileInterface $file */
+      $file = $this->entityTypeManager
+        ->getStorage('file')
+        ->load($result->fid);
+
+      $url = $file->createFileUrl(FALSE);
+      $this->io()->writeln("Marking {$url} for deletion");
+
+      // Temporary files are eventually cleaned by hook_cron.
+      if ($options['no-dry-run']) {
+        $file->setTemporary();
+        $file->save();
+      }
+    }
+
+    if (!$options['no-dry-run']) {
+      $this->io()->warning("Dry run: run with --no-dry-run to actually delete the files");
+    }
+
+    return self::EXIT_SUCCESS;
+  }
+
+}


### PR DESCRIPTION
# [UHF-10737](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10737)

## How to install

`composer require drupal/helfi_azure_fs:dev-UHF-10737-configure-core-file-delete`
`drush updb`

## How to test

- [x] Create media with a file, delete the media.
- [x] Run `drush sqlq "UPDATE file_managed SET changed = changed - 86400 WHERE created >= UNIX_TIMESTAMP(NOW()) - 86400;"`
      File module only deletes files that have not been changed in `system.file:temporary_maximum_age`. This fakes that the file you just uploaded is older that it actually is.
- [x] Run `drush cron`, the file should be deleted (i.e. missing from `/admin/content/files`).
- [x] Test `drush helfi:clean:permanent-files` command on some instance.
- [x] Code follows our standards.

[UHF-10737]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ