### PR TITLE
UHF-12763: Duplicated Add content -button

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,12 @@
     },
     "conflict": {
         "drupal/core": "<11.0"
+    },
+    "extra": {
+        "patches": {
+            "drupal/flysystem": {
+                "[#3525203] Remove duplicated Add content button (https://www.drupal.org/i/3525203)": "./public/modules/contrib/helfi_azure_fs/patches/3525203.patch"
+            }
+        }
     }
 }

--- a/patches/3525203.patch
+++ b/patches/3525203.patch
@@ -1,0 +1,23 @@
+From b9811343b35dc37c3ba45ea672ab816374551384 Mon Sep 17 00:00:00 2001
+From: Jakob Larsen <jakob@revealit.dk>
+Date: Mon, 19 May 2025 09:46:39 +0200
+Subject: [PATCH] Issue #3525203 Remove node action link not needed
+
+---
+ flysystem.links.action.yml | 5 -----
+ 1 file changed, 5 deletions(-)
+ delete mode 100644 flysystem.links.action.yml
+
+diff --git a/flysystem.links.action.yml b/flysystem.links.action.yml
+deleted file mode 100644
+index 68e1953..0000000
+--- a/flysystem.links.action.yml
++++ /dev/null
+@@ -1,5 +0,0 @@
+-flysystem.sync:
+-  route_name: node.add_page
+-  title: 'Add content'
+-  appears_on:
+-    - system.admin_content
+--
+GitLab


### PR DESCRIPTION
# [UHF-12763](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12763)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Added a patch to remove the duplicated 'Add content' button.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Azure FS module
  * `composer require drupal/helfi_azure_fs:dev-UHF-12763 -W`
* Run code updates
  * `composer install`
  * `make drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Check that the `/admin/content` duplicated Add content button is no more.
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->


[UHF-12763]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ