### PR TITLE
UHF-12856: Store imagecache_external images in Azure blob storage

### DIFF
--- a/src/Hook/ImageCacheExternalHooks.php
+++ b/src/Hook/ImageCacheExternalHooks.php
@@ -10,7 +10,7 @@ use Drupal\Core\Hook\Attribute\Hook;
 use Symfony\Component\DependencyInjection\Attribute\AutowireServiceClosure;
 
 /**
- * Provides hooks for 'imagecache_external' module.
+ * Provides hooks for 'imagecach ternal' module.
  */
 final class ImageCacheExternalHooks {
 

--- a/src/Hook/ImageCacheExternalHooks.php
+++ b/src/Hook/ImageCacheExternalHooks.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_azure_fs\Hook;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Hook\Attribute\Hook;
+use Symfony\Component\DependencyInjection\Attribute\AutowireServiceClosure;
+
+/**
+ * Provides hooks for 'imagecache_external' module.
+ */
+final class ImageCacheExternalHooks {
+
+  use AutowireTrait;
+
+  public function __construct(
+    #[AutowireServiceClosure(service: ConfigFactoryInterface::class)] private readonly \Closure $configFactoryClosure,
+  ) {
+  }
+
+  /**
+   * Overrides the file scheme for 'imagecache_external' images.
+   *
+   * @param array<mixed> $alter
+   *   The data to alter.
+   * @param array<mixed> $context
+   *   The context.
+   */
+  #[Hook('imagecache_external_destination_alter')]
+  public function alterDestination(array &$alter, array $context): void {
+    $config = ($this->configFactoryClosure)()
+      ->get('helfi_azure_fs.settings');
+
+    if (!$config->get('use_blob_storage')) {
+      return;
+    }
+    // Override the file scheme. This will cause all external images
+    // to be stored in configured Azure blob storage.
+    $alter['scheme'] = 'azure';
+  }
+
+}

--- a/tests/src/Unit/ImageCacheExternalHooksTest.php
+++ b/tests/src/Unit/ImageCacheExternalHooksTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_azure_fs\Unit;
+
+use Drupal\helfi_azure_fs\Hook\ImageCacheExternalHooks;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * Tests Imagecache external integration.
+ */
+#[Group('helfi_azure_fs')]
+class ImageCacheExternalHooksTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * Tests 'imagecache_external_destination_alter' hook implementation.
+   */
+  public function testSchemeAlter(): void {
+    $alter = [
+      'scheme' => 'public',
+    ];
+    $this->getSut([])
+      ->alterDestination($alter, []);
+
+    $this->assertEquals('public', $alter['scheme']);
+
+    $this->getSut(['use_blob_storage' => FALSE])
+      ->alterDestination($alter, []);
+
+    $this->assertEquals('public', $alter['scheme']);
+
+    $this->getSut(['use_blob_storage' => TRUE])
+      ->alterDestination($alter, []);
+    $this->assertEquals('azure', $alter['scheme']);
+  }
+
+  /**
+   * Gets the SUT.
+   *
+   * @param array $config
+   *   The configuration.
+   *
+   * @return \Drupal\helfi_azure_fs\Hook\ImageCacheExternalHooks
+   *   The SUT.
+   */
+  public function getSut(array $config): ImageCacheExternalHooks {
+    return new ImageCacheExternalHooks(
+      fn() => $this->getConfigFactoryStub(['helfi_azure_fs.settings' => $config]),
+    );
+  }
+
+}

--- a/tests/src/Unit/ImageCacheExternalHooksTest.php
+++ b/tests/src/Unit/ImageCacheExternalHooksTest.php
@@ -42,7 +42,7 @@ class ImageCacheExternalHooksTest extends UnitTestCase {
   /**
    * Gets the SUT.
    *
-   * @param array $config
+   * @param array<mixed> $config
    *   The configuration.
    *
    * @return \Drupal\helfi_azure_fs\Hook\ImageCacheExternalHooks


### PR DESCRIPTION
# [UHF-12856](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12856)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Store all `imagecache_external` images in Azure Blob storage.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your Etusivu instance is up-to-date 
* Update the Helfi Azure FS module
  * `composer require drupal/helfi_azure_fs:dev-UHF-12856`
* Run `drush cr`
* Make sure you have blob storage configured properly. See https://github.com/City-of-Helsinki/drupal-module-helfi-azure-fs#testing-on-local

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Go to https://helfi-etusivu.docker.so/fi/linked-events/image/47460?style=1.5_511w_341h&time=2017-01-03T17:04:01.816571Z
* [ ] Make sure the page is redirected to something like `https://helfi-etusivu.docker.so/fi/_flysystem/azure/styles/1.5_511w_341h/azure/externals/2cca801faa4dd6b0633074e8f5d9531f.jpg?itok=kpffA59P`
* [ ] Make sure there is no file called `public/sites/default/files/externals/2cca801faa4dd6b0633074e8f5d9531f.jpg` on your local


[UHF-12856]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ